### PR TITLE
Bugfix early stopping and set_params

### DIFF
--- a/lib/exgboost/booster.ex
+++ b/lib/exgboost/booster.ex
@@ -127,7 +127,7 @@ defmodule Exgboost.Booster do
           Exgboost.NIF.booster_set_param(booster.ref, Atom.to_string(key), v)
         end)
       else
-        Exgboost.NIF.booster_set_param(booster.ref, Atom.to_string(key), value)
+        Exgboost.NIF.booster_set_param(booster.ref, Atom.to_string(key), to_string(value))
       end
     end
 

--- a/lib/exgboost/training.ex
+++ b/lib/exgboost/training.ex
@@ -97,11 +97,11 @@ defmodule Exgboost.Training do
     callbacks =
       unless is_nil(opts[:early_stopping_rounds]) do
         unless evals_dmats == [] do
-          [{_dmat, target_eval} | _tail] = Enum.reverse(evals_dmats)
+          [{dmat, target_eval} | _tail] = Enum.reverse(evals_dmats)
 
           # TODO: Is this the best way to get the metrics stored in the booster?
           [{_ev_name, metric_name, _metric_value} | _tail] =
-            Booster.eval(bst, target_eval) |> Enum.reverse()
+            Booster.eval(bst, dmat) |> Enum.reverse()
 
           [
             %Callback{

--- a/test/exgboost_test.exs
+++ b/test/exgboost_test.exs
@@ -35,6 +35,15 @@ defmodule ExgboostTest do
     assert Booster.get_boosted_rounds(booster) == num_boost_round
   end
 
+  test "booster params" do
+    x = Nx.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    y = Nx.tensor([0, 1, 2])
+    num_boost_round = 10
+    params = [tree_method: "hist", objective: "multi:softprob", num_class: 3]
+    booster = Exgboost.train(x, y, num_boost_rounds: num_boost_round, params: params)
+    assert Booster.get_boosted_rounds(booster) == num_boost_round
+  end
+
   test "predict", context do
     nrows = :rand.uniform(10)
     ncols = :rand.uniform(10)


### PR DESCRIPTION
Fixes a bug that required all params to be strings and a bug in default early stopping when no metric was supplied