### PR TITLE
Use concatenate on inputs

### DIFF
--- a/c/exgboost/src/exgboost.c
+++ b/c/exgboost/src/exgboost.c
@@ -40,7 +40,6 @@ static ErlNifFunc nif_funcs[] = {
     {"dmatrix_create_from_dense", 2, EXGDMatrixCreateFromDense},
     {"dmatrix_set_str_feature_info", 3, EXGDMatrixSetStrFeatureInfo},
     {"dmatrix_get_str_feature_info", 2, EXGDMatrixGetStrFeatureInfo},
-    {"dmatrix_set_dense_info", 5, EXGDMatrixSetDenseInfo},
     {"dmatrix_num_row", 1, EXGDMatrixNumRow},
     {"dmatrix_num_col", 1, EXGDMatrixNumCol},
     {"dmatrix_num_non_missing", 1, EXGDMatrixNumNonMissing},

--- a/lib/exgboost/nif.ex
+++ b/lib/exgboost/nif.ex
@@ -167,17 +167,6 @@ defmodule EXGBoost.NIF do
   def dmatrix_set_str_feature_info(_dmatrix_resource, _field, _features),
     do: :erlang.nif_error(:not_implemented)
 
-  @deprecated "Use dmatrix_set_info_from_interface/4 instead"
-  @spec dmatrix_set_dense_info(
-          dmatrix_reference(),
-          String.t(),
-          binary,
-          pos_integer(),
-          xgboost_data_type()
-        ) :: :ok | {:error, String.t()}
-  def dmatrix_set_dense_info(_handle, _field, _data, _size, _type),
-    do: :erlang.nif_error(:not_implemented)
-
   @spec dmatrix_num_row(dmatrix_reference()) :: exgboost_return_type(pos_integer())
   def dmatrix_num_row(_handle), do: :erlang.nif_error(:not_implemented)
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule EXGBoost.MixProject do
     [
       {:elixir_make, "~> 0.4", runtime: false},
       {:nimble_options, "~> 0.3.0"},
-      {:nx, "~> 0.5"},
+      {:nx, github: "elixir-nx/nx", sparse: "nx"},
       {:jason, "~> 1.3"},
       {:ex_doc, "~> 0.29.0", only: :docs},
       {:cc_precompiler, "~> 0.1.0", runtime: false, github: "cocoa-xu/cc_precompiler"}

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_options": {:hex, :nimble_options, "0.3.7", "1e52dd7673d36138b1a5dede183b5d86dff175dc46d104a8e98e396b85b04670", [:mix], [], "hexpm", "2086907e6665c6b6579be54ef5001928df5231f355f71ed258f80a55e9f63633"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
-  "nx": {:hex, :nx, "0.5.3", "6ad5534f9b82429dafa12329952708c2fdd6ab01b306e86333fdea72383147ee", [:mix], [{:complex, "~> 0.5", [hex: :complex, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "d1072fc4423809ed09beb729e73c200ce177ddecac425d9eb6fba643669623ec"},
+  "nx": {:git, "https://github.com/elixir-nx/nx.git", "b5ba3af556744f7770f0f987a4c0c29e7cf179dd", [sparse: "nx"]},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "xgboost": {:git, "https://github.com/dmlc/xgboost.git", "191d0aa5cfac87cfc122ebbe8b14da4177309d13", [submodules: true]},
 }

--- a/test/nif_test.exs
+++ b/test/nif_test.exs
@@ -20,7 +20,7 @@ defmodule NifTest do
   end
 
   test "get_global_config" do
-    assert Exgboost.NIF.get_global_config() |> unwrap!() != :error
+    assert EXGBoost.NIF.get_global_config() |> unwrap!() != :error
   end
 
   test "dmatrix_create_from_sparse" do
@@ -156,32 +156,6 @@ defmodule NifTest do
     EXGBoost.NIF.dmatrix_set_str_feature_info(dmat, 'feature_name', ['name', 'color', 'length'])
 
     assert EXGBoost.NIF.dmatrix_get_str_feature_info(dmat, 'feature_name') |> unwrap!()
-  end
-
-  test "dmatrix_set_dense_info" do
-    mat = Nx.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-    array_interface = array_interface(mat) |> Jason.encode!()
-    labels = Nx.tensor([1.0, 0.0])
-    {size} = labels.shape
-
-    config = Jason.encode!(%{"missing" => -1.0})
-
-    dmat =
-      EXGBoost.NIF.dmatrix_create_from_dense(array_interface, config)
-      |> unwrap!()
-
-    type = get_xgboost_data_type(labels) |> unwrap!()
-
-    assert EXGBoost.NIF.dmatrix_set_dense_info(dmat, 'weight', Nx.to_binary(labels), size, type) ==
-             :ok
-
-    assert EXGBoost.NIF.dmatrix_set_dense_info(
-             dmat,
-             'unsupported',
-             Nx.to_binary(labels),
-             size,
-             type
-           ) != :ok
   end
 
   test "dmatrix_num_row" do
@@ -438,6 +412,6 @@ defmodule NifTest do
     config = Jason.encode!(%{"importance_type" => "weight"})
     booster = EXGBoost.NIF.booster_create([dmat]) |> unwrap!()
 
-    EXGBoost.NIF.booster_feature_score(booster, config) |> unwrap!() != :error
+    assert EXGBoost.NIF.booster_feature_score(booster, config) |> unwrap!() != :error
   end
 end


### PR DESCRIPTION
This PR fixes some warnings, failing tests, but primarily it's meant to change the behavior of train and predict to accept Nx containers. After discussing with @josevalim we decided that it was best to use Nx.to_tensor on all inputs so people could implement the Nx container protocol and this library just works with anything compatible with Nx (such as Explorer). After messing with the test I realized concatenate is probably better because all containers will almost always be collections of tensors ---given train and predict require collections (e.g. batches) of inputs. The single concat has no affect on input tensors.